### PR TITLE
Move from template files to template strings

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
   "os"
   "strings"
   "text/template"
+  "./templates"
 )
 
 type SecretData struct{
@@ -49,7 +50,7 @@ func getTemplate() string {
 }
 
 func getSecrets(input io.Reader) map[string]interface{} {
-	var secrets = make(map[string]interface{})
+  var secrets = make(map[string]interface{})
 
   jsonErr := json.NewDecoder(input).Decode(&secrets)
   if jsonErr != nil {
@@ -72,7 +73,7 @@ func encodeValues(secrets map[string]interface{}) map[string]interface{} {
 }
 
 func kubernetesSecrets(secrets map[string]interface{}, file *os.File, flags map[string]string) {
-  secretTmpl := getTemplate()
+  secretTmpl := templates.KubernetesSecretTmpl;
   name := flags["name"]
 
   tmpl, err := template.New("secret").Parse(secretTmpl)

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -1,3 +1,6 @@
+package templates
+
+const KubernetesSecretTmpl = `
 apiVersion: v1
 kind: Secret
 metadata:
@@ -5,3 +8,4 @@ metadata:
 type: Opaque
 data:{{ range $key, $value := .Secrets }}
   {{ $key }}: {{ $value }}{{ end }}
+`


### PR DESCRIPTION
# Summary

Move from template files to strings.

# Test Plan

- Clone the project and build the standalone binary (go build)
- Add the executable to your path `mv main /usr/local/bin/secrets-exporter`
- Use the binary to create a Kubernetes secrets object `echo '{"HELLO":"World"}' | secrets-exporter --export-type=kubernetes --filename=secrets.yaml --name="supersecret"`
- Check to see that the file has been successfully created with the secrets added.
